### PR TITLE
Minor fixes in datetime

### DIFF
--- a/src/parse.py
+++ b/src/parse.py
@@ -241,10 +241,9 @@ def parse_and_write(start_html, currrent_file, previous_month_users):
 
 def main():
     url = 'https://news.ycombinator.com/item?id=' + sys.argv[1]
-    year, month = sys.argv[2].split('-')
 
-    date = datetime(year=int(year), month=int(month), day=1)
-    previous_month = date - timedelta(days=30)
+    date = datetime.strptime(sys.argv[2], '%Y-%m')
+    previous_month = date - timedelta(days=1)
 
     current_file = './web/data/%s.json' % date.strftime('%Y-%m')
     previous_month_file = './web/data/%s.json' %  previous_month.strftime('%Y-%m')


### PR DESCRIPTION
- You can directly parse time using strptime
- Going back 30 days will give wrong result if the current month is March. Since you just need the previous month, going back a single day is more than enough.
